### PR TITLE
Pass authentication header on execute requests

### DIFF
--- a/swift authentication (under development)/js/Swift.js
+++ b/swift authentication (under development)/js/Swift.js
@@ -659,6 +659,9 @@ var recursiveDeleteOnSwift;
 		var xhr = new XMLHttpRequest();
 		xhr.open('POST', xStorageUrl, true);
 		xhr.responseType = 'blob';
+		if (xAuthToken !== null) {
+			xhr.setRequestHeader('X-Auth-Token', xAuthToken);
+		}
 		xhr.setRequestHeader('X-Zerovm-Execute', '1.0');
 		xhr.setRequestHeader('Content-Type', args.contentType);
 		xhr.addEventListener('load', function(e){


### PR DESCRIPTION
My editor did some crazy autowhitespace stuff, which I submitted as I think it is a little nicer.  I'd be happy to repull request with just the auth fix if you prefer.
