### PR TITLE
add `application/x-yaml` to editable text files

### DIFF
--- a/js/FileManager.js
+++ b/js/FileManager.js
@@ -2028,6 +2028,7 @@ FileManager.File.open = function () {
 				|| contentType == 'application/json'
 				|| contentType == 'application/php'
 				|| contentType == 'application/x-php'
+				|| contentType == 'application/x-yaml'
 				|| contentType.indexOf('text') == 0);
 		}
 	}


### PR DESCRIPTION
some browsers (at least FF) upload `yaml` files as `application/x-yaml` instead of `text/x-yaml`
